### PR TITLE
disable new staking with low balance

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -1,5 +1,6 @@
 import invariant from "invariant";
 import React from "react";
+import { BigNumber } from "bignumber.js";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -69,15 +70,17 @@ export function StepDelegationFooter({
 }: StepProps) {
   invariant(account, "account required");
   const { errors } = status;
-  const canNext = !bridgePending && !errors.amount && transaction;
+  const { cardanoResources } = account;
+  const delegation = cardanoResources.delegation;
+  const notEnoughAdaForStaking = delegation && delegation.poolId ? false : new BigNumber(account.balance).isLessThan("3000000");
+  const canNext = !(notEnoughAdaForStaking || !(!bridgePending && !errors.amount && transaction));
   const displayError = errors.amount?.message === "CardanoNotEnoughFunds" ? errors.amount : "";
-
   return (
     <Box horizontal alignItems="center" flow={2} grow>
-      {displayError ? (
+      {notEnoughAdaForStaking || displayError ? (
         <Box grow>
           <Text fontSize={13} color="alertRed">
-            <TranslatedError error={displayError} field="title" />
+            {notEnoughAdaForStaking ? <Trans i18nKey="cardano.delegation.requiredAmountForStaking" /> : <TranslatedError error={displayError} field="title" />}
           </Text>
         </Box>
       ) : (

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2512,6 +2512,7 @@
       "commission": "Commission",
       "stakeKeyRegistrationDeposit": "Stake key registration deposit",
       "delegatingTo": "Delegating to",
+      "requiredAmountForStaking": "Please ensure you have atleast 3 ADA for staking",
       "flow": {
         "title": "Delegate",
         "steps": {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
