### PR TITLE
fix: stake button handle new account - error message for deposit

### DIFF
--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -92,20 +92,13 @@ export default function DelegationSummary({ navigation, route }: Props) {
     return null;
   }, [ledgerPools, pool]);
 
+  let tx = bridge.createTransaction(account);
+  tx = bridge.updateTransaction(tx, { mode: "delegate" });
+
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
     useBridgeTransaction(() => {
-      const tx = route.params.transaction;
-
-      if (!tx && chosenPool) {
-        const t = bridge.createTransaction(mainAccount);
-
-        return {
-          account,
-          transaction: bridge.updateTransaction(t, {
-            mode: "delegate",
-            poolId: chosenPool.poolId,
-          }),
-        };
+      if (chosenPool) {
+        tx = bridge.updateTransaction(tx, { poolId: chosenPool.poolId });
       }
 
       return { account, transaction: tx };
@@ -150,7 +143,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   }, [status, account, parentAccount, navigation, transaction]);
 
   const displayError = useMemo(() => {
-    return status.errors.amount?.message === "CardanoNotEnoughFunds" ? status.errors.amount : "";
+    return status.errors.amount ? status.errors.amount : "";
   }, [status]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/cardano/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/accountActions.tsx
@@ -15,10 +15,14 @@ const getMainActions = ({
   parentAccount: Account;
   parentRoute: RouteProp<ParamListBase, ScreenName>;
 }) => {
+  const isAlreadyDelegated = !!account.cardanoResources?.delegation?.poolId;
+
   const navigationParams = [
     NavigatorName.CardanoDelegationFlow,
     {
-      screen: ScreenName.CardanoDelegationStarted,
+      screen: isAlreadyDelegated
+        ? ScreenName.CardanoDelegationSummary
+        : ScreenName.CardanoDelegationStarted,
       params: {
         accountId: account.id,
         parentId: parentAccount ? parentAccount.id : undefined,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -764,6 +764,9 @@
     "CardanoNotEnoughFunds": {
       "title": "Please ensure you have enough funds to pay for fees"
     },
+    "CardanoStakeKeyDepositError": {
+      "title": "Ensure that you have {{depositAmount}} ADA available for the deposit"
+    },
     "StacksMemoTooLong": {
       "title": "Memo length is too long"
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
