### PR TITLE
fix: disable undelegate on amount error

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -8,6 +8,7 @@ import FormattedVal from "~/renderer/components/FormattedVal";
 import Text from "~/renderer/components/Text";
 import CounterValue from "~/renderer/components/CounterValue";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
+import TranslatedError from "~/renderer/components/TranslatedError";
 import { StepProps } from "../types";
 import BigNumber from "bignumber.js";
 
@@ -96,18 +97,28 @@ export default class StepSummary extends PureComponent<StepProps> {
 }
 export function StepSummaryFooter({ transitionTo, status, bridgePending, transaction }: StepProps) {
   const { errors } = status;
-  const canNext = !bridgePending && !errors.validators && transaction;
+  const canNext = !errors.amount && !bridgePending && !errors.validators && transaction;
+  const displayError = errors.amount?.message ? errors.amount : "";
   return (
     <>
-      <Box horizontal>
-        <Button
-          id="undelegate-continue-button"
-          disabled={!canNext}
-          primary
-          onClick={() => transitionTo("connectDevice")}
-        >
-          <Trans i18nKey="common.continue" />
-        </Button>
+      <Box horizontal alignItems="center" flow={2} grow>
+        {displayError ? (
+          <Box grow>
+            <Text fontSize={13} color="alertRed">
+              <TranslatedError error={displayError} field="title" />
+            </Text>
+          </Box>
+        ) : null}
+        <Box horizontal>
+          <Button
+            id="undelegate-continue-button"
+            disabled={!canNext}
+            primary
+            onClick={() => transitionTo("connectDevice")}
+          >
+            <Trans i18nKey="common.continue" />
+          </Button>
+        </Box>
       </Box>
     </>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
