### PR TITLE
fix: Alert component to display error

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -13,7 +13,7 @@ import ValidatorField from "../fields/ValidatorField";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import TranslatedError from "~/renderer/components/TranslatedError";
-import Text from "~/renderer/components/Text";
+import Alert from "~/renderer/components/Alert";
 
 export default function StepDelegation({
   account,
@@ -76,9 +76,9 @@ export function StepDelegationFooter({
     <Box horizontal alignItems="center" flow={2} grow>
       {displayError ? (
         <Box grow>
-          <Text fontSize={13} color="alertRed">
+          <Alert type="error">
             <TranslatedError error={displayError} field="title" />
-          </Text>
+          </Alert>
         </Box>
       ) : (
         <AccountFooter account={account} status={status} />

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -11,6 +11,7 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import { StepProps } from "../types";
 import BigNumber from "bignumber.js";
+import Alert from "~/renderer/components/Alert";
 
 const FromToWrapper = styled.div``;
 const Separator = styled.div`
@@ -104,9 +105,9 @@ export function StepSummaryFooter({ transitionTo, status, bridgePending, transac
       <Box horizontal alignItems="center" flow={2} grow>
         {displayError ? (
           <Box grow>
-            <Text fontSize={13} color="alertRed">
+            <Alert type="error">
               <TranslatedError error={displayError} field="title" />
-            </Text>
+            </Alert>
           </Box>
         ) : null}
         <Box horizontal>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
