### PR TITLE
fix: conway update for stake deposit

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
@@ -27,13 +27,13 @@ function StepSummary(props: StepProps) {
   const { account, transaction, status, selectedPool } = props;
 
   const feesUnit = useMaybeAccountUnit(account);
-  if (!account || !transaction) return null;
+  if (!account || !transaction || !transaction.protocolParams) return null;
 
   const { estimatedFees, warnings } = status;
   const { feeTooHigh } = warnings;
   const feesCurrency = getAccountCurrency(account);
   const showDeposit = !account.cardanoResources?.delegation?.status;
-  const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
+  const stakeKeyDeposit = transaction.protocolParams.stakeKeyDeposit;
   return (
     <Box flow={4} mx={40}>
       <FromToWrapper>

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -33,10 +33,10 @@ function StepSummary(props: StepProps) {
   const notEnoughFundsError = error && error instanceof CardanoNotEnoughFunds;
 
   const accountUnit = useMaybeAccountUnit(account);
-  if (!account || !transaction) return null;
+  if (!account || !transaction || !account.cardanoResources.delegation) return null;
 
   const feesCurrency = getAccountCurrency(account);
-  const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
+  const stakeKeyDeposit = account.cardanoResources.delegation.deposit;
 
   return (
     <Box flow={4} mx={40}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
