### PR TITLE
feat: update stakeKeyDeposit usage

### DIFF
--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -20,6 +20,7 @@ import type {
   CardanoAccount,
   CardanoDelegation,
   TransactionStatus,
+  Transaction,
 } from "@ledgerhq/live-common/families/cardano/types";
 import { Box, Text } from "@ledgerhq/native-ui";
 import { AccountLike } from "@ledgerhq/types-live";
@@ -190,6 +191,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
             chosenPool={chosenPool ?? undefined}
             account={account}
             status={status}
+            transaction={transaction}
           />
         </View>
       </View>
@@ -336,6 +338,7 @@ function SummaryWords({
   isFetchingPoolDetails,
   onChangePool,
   status,
+  transaction,
 }: {
   chosenPool?: StakePool;
   account: AccountLike;
@@ -343,6 +346,7 @@ function SummaryWords({
   isFetchingPoolDetails: boolean;
   onChangePool: () => void;
   status: TransactionStatus;
+  transaction: Transaction;
 }) {
   const unit = useAccountUnit(account);
   const { t } = useTranslation();
@@ -574,9 +578,7 @@ function SummaryWords({
               <LText numberOfLines={1} semiBold ellipsizeMode="middle" style={[styles.valueText]}>
                 {formatCurrencyUnit(
                   unit,
-                  new BigNumber(
-                    (account as CardanoAccount).cardanoResources.protocolParams.stakeKeyDeposit,
-                  ),
+                  new BigNumber(transaction.protocolParams?.stakeKeyDeposit ?? "0"),
                   formatConfig,
                 )}
               </LText>

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -260,6 +260,11 @@ function SummaryWords({
   const { t } = useTranslation();
   const { colors } = useTheme();
 
+  invariant((account as CardanoAccount).cardanoResources.delegation, "delegation must be defined");
+  const depositRefundAmount = new BigNumber(
+    (account as CardanoAccount).cardanoResources.delegation!.deposit,
+  );
+
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,
@@ -295,7 +300,7 @@ function SummaryWords({
           label={t("cardano.delegation.stakeKeyRegistrationDepositRefund")}
           Component={
             <LText numberOfLines={1} semiBold ellipsizeMode="middle" style={[styles.valueText]}>
-              {formatCurrencyUnit(unit, new BigNumber(2000000), formatConfig)}
+              {formatCurrencyUnit(unit, depositRefundAmount, formatConfig)}
             </LText>
           }
         />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
